### PR TITLE
Add Basic Authentication support to HttpPushClient

### DIFF
--- a/Sources/LokiLoggingProvider/LoggerFactories/HttpLoggerFactory.cs
+++ b/Sources/LokiLoggingProvider/LoggerFactories/HttpLoggerFactory.cs
@@ -4,6 +4,8 @@ namespace LokiLoggingProvider.LoggerFactories
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Text;
     using LokiLoggingProvider.Formatters;
     using LokiLoggingProvider.Logger;
     using LokiLoggingProvider.Options;
@@ -36,6 +38,12 @@ namespace LokiLoggingProvider.LoggerFactories
             {
                 BaseAddress = new Uri(httpOptions.Address),
             };
+
+            if (!string.IsNullOrEmpty(httpOptions.User) && !string.IsNullOrEmpty(httpOptions.Password))
+            {
+                byte[] credentials = Encoding.ASCII.GetBytes($"{httpOptions.User}:{httpOptions.Password}");
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(credentials));
+            }
 
             HttpPushClient pushClient = new(httpClient);
             this.processor = new LokiLogEntryProcessor(pushClient);

--- a/Sources/LokiLoggingProvider/Options/HttpOptions.cs
+++ b/Sources/LokiLoggingProvider/Options/HttpOptions.cs
@@ -4,5 +4,11 @@ namespace LokiLoggingProvider.Options
     {
         /// <summary>The destination to send logs to. Defaults to "http://localhost:3100".</summary>
         public string Address { get; set; } = "http://localhost:3100";
+
+        /// <summary>The user used to authenticate to a reverse proxy or Grafana Cloud.</summary>
+        public string User { get; set; } = string.Empty;
+
+        /// <summary>The password used to authenticate to a reverse proxy or Grafana Cloud.</summary>
+        public string Password { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
This PR adds support for Basic Authentication to HttpPushClient when setting a user and password in the configuration.