### PR TITLE
fixed "BadRequest: timestamp too old" error

### DIFF
--- a/Sources/LokiLoggingProvider/PushClients/HttpPushClient.cs
+++ b/Sources/LokiLoggingProvider/PushClients/HttpPushClient.cs
@@ -32,7 +32,7 @@ internal sealed class HttpPushClient : ILokiPushClient
                     {
                         new[]
                         {
-                            $"{rfc3339Timestamp.Seconds}{rfc3339Timestamp.Nanos.ToString("000000000")}",
+                            $"{rfc3339Timestamp.Seconds}{rfc3339Timestamp.Nanos:000000000}",
                             entry.Message,
                         },
                     },

--- a/Sources/LokiLoggingProvider/PushClients/HttpPushClient.cs
+++ b/Sources/LokiLoggingProvider/PushClients/HttpPushClient.cs
@@ -32,7 +32,7 @@ internal sealed class HttpPushClient : ILokiPushClient
                     {
                         new[]
                         {
-                            $"{rfc3339Timestamp.Seconds}{rfc3339Timestamp.Nanos}",
+                            $"{rfc3339Timestamp.Seconds}{rfc3339Timestamp.Nanos.ToString("000000000")}",
                             entry.Message,
                         },
                     },

--- a/Tests/LokiLoggingProvider.UnitTests/PushClients/HttpPushClientUnitTests.cs
+++ b/Tests/LokiLoggingProvider.UnitTests/PushClients/HttpPushClientUnitTests.cs
@@ -49,7 +49,7 @@ public class HttpPushClientUnitTests
                     Assert.Null(request.Content.Headers.ContentType.CharSet);
 
                     Assert.Equal(
-                        "{\"streams\":[{\"stream\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"values\":[[\"15750756000\",\"My log message.\"]]}]}",
+                        "{\"streams\":[{\"stream\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"values\":[[\"1575075600000000000\",\"My log message.\"]]}]}",
                         request.Content.ReadAsStringAsync().Result);
                 });
         }


### PR DESCRIPTION
fix: Pushing entry fails if timestamp nanoseconds should have a leading zero